### PR TITLE
🛠 fix: add no-op build script for Netlify CI pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.4.1
+
+### 🛠 Fix: Add build script for Netlify CI
+- What: Added a no-op `build` script to `package.json` so Netlify build/test pipeline will not fail.
+- Why: Netlify requires a `build` script even for static JS/HTML projects; without it, CI/CD fails before tests run.
+- How: Inserted `"build": "echo 'No build step'"` to the scripts section of `package.json`.
+
 ## [v1.5.1] - 2025-05-22
 
 ### 🛡️ Failsafe: Enhance player-terrain fallback logic

--- a/llm-notes.md
+++ b/llm-notes.md
@@ -40,6 +40,7 @@
     ```
 - **Reference:** This fixes CI errors like `window is not defined`, `Phaser is not defined`, and Web Crypto API issues in tests.
 - See also: common-issues.md for troubleshooting.
+- Netlify requires a `build` script in `package.json`, even for static JS/HTML projects. Use a no-op if not needed, or CI will fail before running tests.
 
 ## Common API Misuse: RotationSystem.update
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "bitstream-bluffs",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "description": "2D side-scrolling infinite sledder game",
   "scripts": {
+    "build": "echo 'No build step'",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",


### PR DESCRIPTION
This pull request addresses an issue with the Netlify CI/CD pipeline by adding a no-op `build` script to the `package.json` file. This ensures that the pipeline does not fail for static JS/HTML projects that do not require a build step. The changelog and documentation have been updated accordingly.

### Fixes for Netlify CI/CD pipeline:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R7): Added a no-op `build` script (`"build": "echo 'No build step'"`) to prevent Netlify CI/CD failures for static projects. Updated the version to `1.4.1`.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9): Documented the addition of the `build` script under version `1.4.1`.
* [`llm-notes.md`](diffhunk://#diff-677dec6bfd75060a6a8e8363e634f47ba02dfb5776052623205ace949b9d57a1R43): Added a note explaining the necessity of a `build` script in `package.json` for Netlify pipelines, even for static projects.